### PR TITLE
fix(cohorts): fetch cohorts on on hover dropdown

### DIFF
--- a/src/actions/EngineerActions.js
+++ b/src/actions/EngineerActions.js
@@ -129,6 +129,29 @@ export const fetchEngineer = (id) => async (dispatch) => {
       type: FETCH_ENGINEER,
       payload: user,
     });
+    if (user) {
+      const res2 = await axios.get(
+        `${baseUrl}/api/v1/cohorts`,
+        {
+          method: 'GET',
+          mode: 'cors',
+          cache: 'no-cache',
+          credentials: 'same-origin',
+          headers: {
+            Authorization: `Bearer ${token}`,
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': `${process.env.API_URL}`,
+          },
+        }
+      );
+      const { data: cohort } = res2.data;
+      console.log('cohorts', cohort);
+      dispatch({
+        type: GET_COHORTS,
+        payload: cohort,
+      });
+    }
+
     const res1 = await axios.get(
       `${baseUrl}/api/v1/programs`,
       {
@@ -156,26 +179,6 @@ export const fetchEngineer = (id) => async (dispatch) => {
     dispatch({
       type: CHANGE_PROGRAM,
       payload: [],
-    });
-    const res2 = await axios.get(
-      `${baseUrl}/api/v1/cohorts`,
-      {
-        method: 'GET',
-        mode: 'cors',
-        cache: 'no-cache',
-        credentials: 'same-origin',
-        headers: {
-          Authorization: `Bearer ${token}`,
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': `${process.env.API_URL}`,
-        },
-      }
-    );
-    const { data: cohort } = res2.data;
-    console.log('cohorts', cohort);
-    return dispatch({
-      type: GET_COHORTS,
-      payload: cohort,
     });
   } catch (error) {
     console.log('the response is : ', error);

--- a/src/components/AdminDashboard.js
+++ b/src/components/AdminDashboard.js
@@ -44,7 +44,7 @@ const sideMenus = [
     icon: <MailIcon />,
     link: '/admin/emails',
   },
-  ];
+];
 
 export default function AdminDashboard(props) {
   const classes = useStyles();
@@ -53,7 +53,10 @@ export default function AdminDashboard(props) {
     <>
       <div className={classes.root}>
         <CssBaseline />
-        <AppBar position="absolute" className={classes.appBar}>
+        <AppBar
+          position="absolute"
+          className={classes.appBar}
+        >
           <Header />
         </AppBar>
         <Drawer
@@ -67,7 +70,13 @@ export default function AdminDashboard(props) {
           <div className={classes.drawerContainer}>
             <List>
               {sideMenus.map((menu, index) => (
-                <ListItem button key={menu.text} onClick={() => props.history.push(menu.link)}>
+                <ListItem
+                  button
+                  key={menu.text}
+                  onClick={() =>
+                    props.history.push(menu.link)
+                  }
+                >
                   <ListItemIcon>{menu.icon}</ListItemIcon>
                   <ListItemText primary={menu.text} />
                 </ListItem>

--- a/src/components/AuthorizeEmails.js
+++ b/src/components/AuthorizeEmails.js
@@ -1,5 +1,9 @@
 import React, { Component } from 'react';
-import { NavLink, Link, withRouter } from 'react-router-dom';
+import {
+  NavLink,
+  Link,
+  withRouter,
+} from 'react-router-dom';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import RemoveCircleIcon from '@material-ui/icons/RemoveCircle';
@@ -17,18 +21,19 @@ class AuthorizedEmails extends Component {
   handleCopy = (e) => {
     console.log(e.target.id);
     navigator.clipboard.writeText(e.target.id);
-  }
+  };
 
   render() {
     const { emails } = this.props.emails;
     return (
       <>
         <div className="emailsContainer">
-          <p className="tableHeader">Manage allowed emails</p>
+          <p className="tableHeader">
+            Manage allowed emails
+          </p>
           <div className="maincontainer">
             <div className="addRemoveWrapper">
               <div className="addSection">
-
                 <AddEmails />
               </div>
               <div className="removeSection">
@@ -38,42 +43,45 @@ class AuthorizedEmails extends Component {
             <div className="viewEmailsContainer">
               <h3>All authorized emails</h3>
               <div className="allEmails">
-                { emails.length ? null : <h5>No email(s) saved yet</h5> }
-                {
-                    emails.map((eachEmail) => (
-                      <div className="eachEmail" key={eachEmail.email}>
-                        <p>{eachEmail.email}</p>
-                        <button
-                          id={eachEmail.email}
-                          onClick={this.handleCopy}
-                          type="button"
-                        >
-                          <FileCopyOutlinedIcon
-                            id={eachEmail.email}
-                            onClick={this.handleCopy}
-                            className="removeIcon"
-                            color="secondary"
-                          />
-                        </button>
-                      </div>
-                    ))
-                }
-
+                {emails.length ? null : (
+                  <h5>No email(s) saved yet</h5>
+                )}
+                {emails.map((eachEmail) => (
+                  <div
+                    className="eachEmail"
+                    key={eachEmail.email}
+                  >
+                    <p>{eachEmail.email}</p>
+                    <button
+                      id={eachEmail.email}
+                      onClick={this.handleCopy}
+                      type="button"
+                    >
+                      <FileCopyOutlinedIcon
+                        id={eachEmail.email}
+                        onClick={this.handleCopy}
+                        className="removeIcon"
+                        color="secondary"
+                      />
+                    </button>
+                  </div>
+                ))}
               </div>
             </div>
-
           </div>
         </div>
       </>
     );
   }
 }
-const mapStateToProps = (state) => ({ emails: state.emailList || [] });
+const mapStateToProps = (state) => ({
+  emails: state.emailList || [],
+});
 const mapDispatchToProps = (dispatch) => ({
   getEmails: () => dispatch(getEmailsList()),
 });
 
 export default compose(
   withRouter,
-  connect(mapStateToProps, mapDispatchToProps),
+  connect(mapStateToProps, mapDispatchToProps)
 )(AuthorizedEmails);

--- a/src/components/shared/SnackBarMessage.js
+++ b/src/components/shared/SnackBarMessage.js
@@ -18,13 +18,22 @@ export const SuccessSnackBarMessage = (props) => {
         onClose={close}
         message={message}
         key={`${message}`}
-        action={(
+        action={
           <>
-            <IconButton style={{ backgroundColor: 'green', color: 'white' }} size="small" aria-label="close" color="inherit" onClick={close}>
+            <IconButton
+              style={{
+                backgroundColor: 'green',
+                color: 'white',
+              }}
+              size="small"
+              aria-label="close"
+              color="inherit"
+              onClick={close}
+            >
               <CloseIcon fontSize="small" />
             </IconButton>
           </>
-        )}
+        }
       />
     </div>
   );
@@ -46,13 +55,22 @@ export const ErrorSnackBarMessage = (props) => {
         onClose={close}
         message={message}
         key={`${message}`}
-        action={(
+        action={
           <>
-            <IconButton style={{ backgroundColor: 'red', color: 'white' }} size="small" aria-label="close" color="inherit" onClick={close}>
+            <IconButton
+              style={{
+                backgroundColor: 'red',
+                color: 'white',
+              }}
+              size="small"
+              aria-label="close"
+              color="inherit"
+              onClick={close}
+            >
               <CloseIcon fontSize="small" />
             </IconButton>
           </>
-        )}
+        }
       />
     </div>
   );

--- a/src/components/shared/admin/removeEmails.js
+++ b/src/components/shared/admin/removeEmails.js
@@ -2,14 +2,23 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import {
-  Accordion, AccordionDetails, AccordionSummary, Button, IconButton, Snackbar, TextField,
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Button,
+  IconButton,
+  Snackbar,
+  TextField,
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import CloseIcon from '@material-ui/icons/Close';
 import ConfirmationDialog from '../DeleteConfirmPopup';
 import { removeAuthorizedEmail } from '../../../actions/emailList';
-import { ErrorSnackBarMessage, SuccessSnackBarMessage } from '../SnackBarMessage';
+import {
+  ErrorSnackBarMessage,
+  SuccessSnackBarMessage,
+} from '../SnackBarMessage';
 
 class RemoveEmails extends Component {
   snack = null;
@@ -56,119 +65,126 @@ class RemoveEmails extends Component {
     }
   }
 
-  handleChange = (event, value) => this.setState({ emails: value })
+  handleChange = (event, value) =>
+    this.setState({ emails: value });
 
   handleRemoveEmails = () => {
     const { removeAuthorizedEmail } = this.props;
     console.log('going to be removed', this.state.emails);
     const emails = [];
-    this.state.emails.map((email) => emails.push(email.email));
+    this.state.emails.map((email) =>
+      emails.push(email.email)
+    );
     console.log('actualemails', emails, emails.length);
     removeAuthorizedEmail(emails);
     return this.setState({ openDialog: false });
-  }
+  };
 
-    confirmDeleteEmails = () => {
-      if (this.state.emails.length) {
-        return this.openConfirDialog();
-      }
-      return null;
+  confirmDeleteEmails = () => {
+    if (this.state.emails.length) {
+      return this.openConfirDialog();
     }
+    return null;
+  };
 
-    closeDialog = () => this.setState({ openDialog: false });
+  closeDialog = () => this.setState({ openDialog: false });
 
-    openConfirDialog = () => {
-      console.log('changing click');
-      this.setState({ openDialog: true });
-    }
+  openConfirDialog = () => {
+    console.log('changing click');
+    this.setState({ openDialog: true });
+  };
 
-    handleCloseSnackSuccess = () => {
-      this.setState({
-        snackMessageData: {
-          open: false,
-          message: '',
-        },
-        snackMessageError: {
-          open: false,
-          message: '',
-        },
-      });
-    }
+  handleCloseSnackSuccess = () => {
+    this.setState({
+      snackMessageData: {
+        open: false,
+        message: '',
+      },
+      snackMessageError: {
+        open: false,
+        message: '',
+      },
+    });
+  };
 
-    render() {
-      const { emailsList } = this.props;
-      const { snackMessageData, snackMessageError } = this.state;
-      return (
-        <>
-          <SuccessSnackBarMessage
-            open={snackMessageData.open}
-            message={snackMessageData.message}
-            close={this.handleCloseSnackSuccess}
-          />
-          <ErrorSnackBarMessage
-            open={snackMessageError.open}
-            message={snackMessageError.message}
-            close={this.handleCloseSnackSuccess}
-          />
-          <ConfirmationDialog
-            openDialog={this.state.openDialog}
-            closeDialog={this.closeDialog}
-            items={this.state.emails.length}
-            confirmed={this.handleRemoveEmails}
-          />
+  render() {
+    const { emailsList } = this.props;
+    const { snackMessageData, snackMessageError } =
+      this.state;
+    return (
+      <>
+        <SuccessSnackBarMessage
+          open={snackMessageData.open}
+          message={snackMessageData.message}
+          close={this.handleCloseSnackSuccess}
+        />
+        <ErrorSnackBarMessage
+          open={snackMessageError.open}
+          message={snackMessageError.message}
+          close={this.handleCloseSnackSuccess}
+        />
+        <ConfirmationDialog
+          openDialog={this.state.openDialog}
+          closeDialog={this.closeDialog}
+          items={this.state.emails.length}
+          confirmed={this.handleRemoveEmails}
+        />
 
-          <Accordion>
-            <AccordionSummary
-              expandIcon={<ExpandMoreIcon />}
-              aria-controls="panel2a-content"
-              id="remove-emails"
+        <Accordion>
+          <AccordionSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel2a-content"
+            id="remove-emails"
+          >
+            <h3>Remove Emails</h3>
+          </AccordionSummary>
+          <AccordionDetails className="removeWrapper">
+            <Autocomplete
+              multiple
+              className="autoCompleteInput"
+              options={emailsList}
+              getOptionLabel={(option) => option.email}
+              value={this.state.emails}
+              onChange={this.handleChange}
+              filterSelectedOptions
+              renderInput={(params) => (
+                <>
+                  <TextField
+                    {...params}
+                    variant="outlined"
+                    placeholder="Add comma separated emails"
+                  />
+                </>
+              )}
+            />
+            <Button
+              onClick={this.confirmDeleteEmails}
+              className="removeButton"
+              variant="contained"
+              color="secondary"
             >
-              <h3>Remove Emails</h3>
-            </AccordionSummary>
-            <AccordionDetails className="removeWrapper">
-              <Autocomplete
-                multiple
-                className="autoCompleteInput"
-                options={emailsList}
-                getOptionLabel={(option) => option.email}
-                value={this.state.emails}
-                onChange={this.handleChange}
-                filterSelectedOptions
-                renderInput={(params) => (
-                  <>
-                    <TextField
-                      {...params}
-                      variant="outlined"
-                      placeholder="Add comma separated emails"
-                    />
-                  </>
-                )}
-              />
-              <Button
-                onClick={this.confirmDeleteEmails}
-                className="removeButton"
-                variant="contained"
-                color="secondary"
-              >
-                Remove
-                {' '}
-              </Button>
-            </AccordionDetails>
-          </Accordion>
-        </>
-      );
-    }
+              Remove{' '}
+            </Button>
+          </AccordionDetails>
+        </Accordion>
+      </>
+    );
+  }
 }
 RemoveEmails.propTypes = {
   emails: PropTypes.object.isRequired,
   removeAuthorizedEmail: PropTypes.func.isRequired,
 };
 
-
-const mapStateToProps = (state) => ({ emails: state.emailList || [] });
+const mapStateToProps = (state) => ({
+  emails: state.emailList || [],
+});
 
 const mapDispatchToProps = {
   removeAuthorizedEmail,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(RemoveEmails);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(RemoveEmails);


### PR DESCRIPTION
#### What does this PR do?

- this fixes on hover dropdown to change cohorts
#### Description of Task to be completed?

- when there were a bug that when you reload the page the app does not fetch cohorts on the dropdown
 - so this fixes that now whenever you reload you will be able to change cohorts.
#### How should this be manually tested?

- `git checkout fix-change-cohort` to go to this branch
- `yarn dev` to start the app
 - login as manager
 - click on a trainee
 - then hover on the icons
 - reload and then hover again.
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[]()
#### Screenshots (if appropriate)
#### Questions:
N/A