### PR TITLE
fix(button):remove profile & rate btn on trainees side

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Developer Rating manager App",
   "scripts": {
-    "postinstall": "NODE_ENV=production webpack --mode production",
+    "postinstall": "webpack --mode production",
     "dev": "webpack-dev-server --config webpack.config.dev.js --open --hot",
     "start": "node server.js",
     "test": "jest --coverage"

--- a/src/components/shared/Header.js
+++ b/src/components/shared/Header.js
@@ -1,5 +1,9 @@
 import React, { Component } from 'react';
-import { NavLink, Link, withRouter } from 'react-router-dom';
+import {
+  NavLink,
+  Link,
+  withRouter,
+} from 'react-router-dom';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
@@ -23,10 +27,7 @@ class Header extends Component {
       if (profile.success.data.role === 'Manager') {
         this.adminDashboard = (
           <li>
-            <NavLink
-              to="/admin"
-              title="Admin Dashboard"
-            >
+            <NavLink to="/admin" title="Admin Dashboard">
               <i className="fas fa-user" />
               <span className="m-1">Admin</span>
             </NavLink>
@@ -36,40 +37,49 @@ class Header extends Component {
     }
   }
 
-logOut = () => {
-  localStorage.removeItem('pulseToken');
-}
+  logOut = () => {
+    localStorage.removeItem('pulseToken');
+  };
 
-render() {
-  return (
-    <>
-      <nav className="navbar">
-        <img className="logo-img" src="https://res.cloudinary.com/bahati/image/upload/v1572334416/samples/Mystuff/pulse_vjdvgh.png" />
-        <h1>
-          <i className="fas fa-code" />
-          {' '}
-          PULSE
-        </h1>
-        <ul>
-          {this.adminDashboard}
-          <li>
-            <NavLink
-              to="/profile"
-              title="Dashboard"
-            >
-              <i className="fas fa-user" />
-              <span className="m-1">Profile</span>
-
-            </NavLink>
-          </li>
-          <li><Link onClick={() => this.logOut()} to="/login">Sign Out</Link></li>
-        </ul>
-      </nav>
-    </>
-  );
+  render() {
+    const userRole = localStorage.getItem('pulseRole');
+    return (
+      <>
+        <nav className="navbar">
+          <img
+            className="logo-img"
+            src="https://res.cloudinary.com/bahati/image/upload/v1572334416/samples/Mystuff/pulse_vjdvgh.png"
+          />
+          <h1>
+            <i className="fas fa-code" /> PULSE
+          </h1>
+          <ul>
+            {this.adminDashboard}
+            {userRole === 'Manager' && (
+              <li>
+                <NavLink to="/profile" title="Dashboard">
+                  <i className="fas fa-user" />
+                  <span className="m-1">Profile</span>
+                </NavLink>
+              </li>
+            )}
+            <li>
+              <Link
+                onClick={() => this.logOut()}
+                to="/login"
+              >
+                Sign Out
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </>
+    );
+  }
 }
-}
-const mapStateToProps = (state) => ({ profile: state.profile });
+const mapStateToProps = (state) => ({
+  profile: state.profile,
+});
 
 const mapDispatchToProps = (dispatch) => ({
   getProfile: () => dispatch(fetchProfile()),
@@ -77,5 +87,5 @@ const mapDispatchToProps = (dispatch) => ({
 
 export default compose(
   withRouter,
-  connect(mapStateToProps, mapDispatchToProps),
+  connect(mapStateToProps, mapDispatchToProps)
 )(Header);

--- a/src/components/singleEngineer.js
+++ b/src/components/singleEngineer.js
@@ -207,14 +207,16 @@ class SingleEngineer extends React.Component {
               <li className="profile-bar-item">
                 <ProgramDropDown />
               </li>
-              <li className="profile-bar-item">
-                <Link
-                  className="btn"
-                  to={'/ratings/rate/' + user.id}
-                >
-                  Rate
-                </Link>
-              </li>
+              {userRole === 'Manager' && (
+                <li className="profile-bar-item">
+                  <Link
+                    className="btn"
+                    to={'/ratings/rate/' + user.id}
+                  >
+                    Rate
+                  </Link>
+                </li>
+              )}
             </ul>
           </div>
           <div>


### PR DESCRIPTION
#### What does this PR do?

This PR fixes showing Profile and Rate button when logged in as trainee.

#### Description of Task to be completed?

- Remove profile button when logged in as trainee.
- Remove Rate button when logged in as trainee.
 
#### How should this be manually tested?

 - go to the branch by running `git checkout fix-profile-btn`
 - `yarn run dev` to start the project 
 - login as a trainee and you should not be able to see both profile button and Rate button
 
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[]()
#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/47631065/132415031-cd3706ec-8fe4-4486-83b9-94e422767192.png)

#### Questions:
N/A