### PR TITLE
adds paste feature for multiple emails

### DIFF
--- a/src/components/shared/InputTags.js
+++ b/src/components/shared/InputTags.js
@@ -35,6 +35,27 @@ const InputTags = (props) => {
   const deleteTag = (index) => {
     setTags(tags.filter((tag, i) => i !== index));
   };
+  const breakDownIntoEmails = (text,separator) =>{
+    return text.split(separator).map((tag) => tag.trim());
+  }
+  const filterExistingEmails = (emails,existingEmails) =>{
+    let filtered = [];
+    pastedTags.forEach(tag => {
+      if(!tagsCopy.includes(tag)) {
+        filtered.push(tag);
+      }
+    });
+  }
+  const handlePaste =(e) => {
+    e.preventDefault();
+    const { clipboardData } = e;
+    const pastedText = clipboardData.getData('Text');
+    const emails = pastedText.split(/[,\s]+/);
+    const allEmails = [ ...tags, ...emails];
+    const filtered = new Set(allEmails);
+    setTags([...filtered]);
+    setInput('');
+  };
   return (
     <div className="tagContainer">
       {tags.map((tag, index) => (
@@ -51,6 +72,7 @@ const InputTags = (props) => {
         onChange={onChange}
         type="email"
         required
+        onPaste={handlePaste}
       />
     </div>
 


### PR DESCRIPTION
#### What does this PR do?
The PR holds changes that will allow the admin to paste multiple emails,  (commas or space separated emails)
#### Description of Task to be completed?
the admin will be able to copy and paste many emails
#### How should this be manually tested?
- checkout on `ft-multiemails-paste` 
- run yarn dev
- navigate on the admin dashboard
- copy many separated emails and pasted the in the input box
- save the emails and enjoy your configuration 😉️
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[]()
#### Screenshots (if appropriate)
#### Questions:
N/A