### PR TITLE
Ft cleaning radio button

### DIFF
--- a/src/components/attendance/AttendanceForm.js
+++ b/src/components/attendance/AttendanceForm.js
@@ -19,7 +19,7 @@ import { getAllCohorts } from '../../actions/cohorts'
 import { getAllPrograms } from '../../actions/programs'
 import { toast } from 'react-toastify';
 import Filters from './Filters';
-
+import './../../styles/attendanceForm.scss'
 
 const customStyles = {
 
@@ -162,37 +162,37 @@ const AttendanceForm = ({ history, ...props }) => {
   },
   {
     name: '2',
-    cell: ({ id }) => <div> <Radio
-      checked={isChecked(id) === 2 ? true : null}
+    cell: ({ id }) => <div className='radio'> <input
+      style={{height: "24px", width: "24px",zIndex:"1", verticalAlign: "middle"}}
       onChange={() => handleChange(id, 'attendance', 2)}
-      value="a"
-      name="radio-button-demo"
-      inputProps={{ 'aria-label': 'A' }}
-    /></div>,
+      type="radio"
+      className="radio-label"
+      name={`radio-button-demo-${id}`}
+    /><label for="radio-1" className="radio-label"></label>
+    </div>,
     center: true,
   },
   {
     name: '1',
-    cell: ({ id }) => <div > <Radio
-      checked={isChecked(id) === 1 ? true : null}
+    cell: ({ id }) => <div > <input
+      style={{height: "24px", width: "24px",zIndex:"1", verticalAlign: "middle"}}
       onChange={() => handleChange(id, 'attendance', 1)}
-      value="a"
-      name="radio-button-demo"
-      inputProps={{ 'aria-label': 'A' }}
-    /></div>,
+      type="radio"
+      name={`radio-button-demo-${id}`}
+    /><label for="radio-2" className="radio-label"></label>
+    </div>,
     center: true,
   },
   {
     center: true,
     name: '0',
-    cell: ({ id }) => <div> <Radio
-      checked={isChecked(id) === 0 ? true : null}
+    cell: ({ id }) => <div> <input
+      style={{height: "24px", width: "24px",zIndex:"1", verticalAlign: "middle"}}
       onChange={() => handleChange(id, 'attendance', 0)}
-      value="a"
-      name="radio-button-demo"
-      inputProps={{ 'aria-label': 'A' }}
-    />
-      <i onClick={() => openDialog(id)} style={{ marginLeft: '10px', cursor: 'pointer', position: 'absolute', marginTop: '15px' }} className="fas fa-ellipsis-h ml-2"></i>
+      type="radio"
+      name={`radio-button-demo-${id}`}
+    /><label for="radio-1" className="radio-label"></label>
+      <i onClick={() => openDialog(id)} style={{ marginLeft: '10px', cursor: 'pointer', position: 'absolute', marginTop: '5px' }} className="fas fa-ellipsis-h ml-2"></i>
     </div>
   },
   ];

--- a/src/styles/attendanceForm.scss
+++ b/src/styles/attendanceForm.scss
@@ -1,0 +1,43 @@
+$color1: #f4f4f4;
+$color2: #3197EE;
+
+
+  input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    + .radio-label {
+      &:before {
+        content: '';
+        background: $color1;
+        border-radius: 100%;
+        border: 1px solid darken($color1, 25%);
+        display: inline-block;
+        width: 1.4em;
+        height: 1.4em;
+        position: relative;
+        top: -0.2em;
+        margin-right: 1em; 
+        vertical-align: top;
+        cursor: pointer;
+        text-align: center;
+        transition: all 250ms ease;
+      }
+    }
+    &:checked {
+      + .radio-label {
+        &:before {
+          background-color: $color2;
+          box-shadow: inset 0 0 0 4px $color1;
+        }
+      }
+    }
+    &:focus {
+      + .radio-label {
+        &:before {
+          outline: none;
+          border-color: $color2;
+        }
+      }
+    }
+   
+  }


### PR DESCRIPTION
#### What does this PR do?
- This Pull Request cleans radio buttons after making attendance
#### Description of Task to be completed?
- Login in the system as Manager
- 'create' cohorts and their corresponding activities like programs
- Click on the `profile` to edit your List after editing the list
- Click one of your trainees to `rate` him/her
- after that go to `attendance` and click on the `+` icon to grade your trainees
- If the rating attendant is successfully you will be redirected to the `attendance` list
- you can return to make `attendance` again  you will find that that radio buttons are cleaned
#### How should this be manually tested?
- clone this repository if you don't have
- do `yarn install` to install dependencies
- checkout into `ft_cleanig_botton` 
- Edit in `webpack-config.dev.js` on `jwt secret key ` put key same as what you used on the backend
- run `yarn dev` on both side backend and Frontend
- and Then follow steps stated in `PR Description`

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[]()
#### Screenshots (if appropriate)
![before](https://user-images.githubusercontent.com/41394162/152783401-3abd6c1a-568f-4a8f-8de1-99635b32aae1.png)
![after](https://user-images.githubusercontent.com/41394162/152783405-db902f49-2713-420b-9324-152483477717.png)

#### Questions:
N/A